### PR TITLE
Get CSA code building clean

### DIFF
--- a/csa/parse.c
+++ b/csa/parse.c
@@ -72,7 +72,7 @@ extern	int	abs();
 
 /* skip initial comments */
 do
-  if (gets(in_line) == NULL)
+  if (fgets(in_line, sizeof(in_line), stdin) == NULL)
     parse_error(BADINPUT1);
 while (in_line[0] == 'c');
 
@@ -86,7 +86,7 @@ if ((sscanf(in_line, "%c%3s%d%d", &line_type, prob_type, &n, &m) != 4) ||
 arc_count = 0;
 lhs_n = 0;
 
-while (gets(in_line) != NULL)
+while (fgets(in_line, sizeof(in_line), stdin) != NULL)
   switch (in_line[0])
     {
     case 'c': break;

--- a/csa/prec_costs/Makefile
+++ b/csa/prec_costs/Makefile
@@ -28,6 +28,13 @@
 BASEFILES=main.c refine.c update_epsilon.c parse.c stack.c timer.c debug.c
 HEADERS=csa_types.h csa_defs.h
 CFLAGS=-O4
+TARGETS=csa_s csa_s_qm csa_q csa_q_qm csa_s_pr csa_q_pr csa_s_pr_qm csa_s_pu csa_s_pu_qm csa_q_pu csa_s_pr_pu csa_q_pr_pu csa_s_tpo csa_s_tpo_qm csa_q_tpo csa_s_rtpo csa_q_rtpo csa_s_rtpo_qm csa_s_spo csa_s_spo_qm csa_q_spo csa_s_rspo csa_s_rspo_qm csa_q_rspo csa_s_tpo_pr csa_q_tpo_pr csa_s_rtpo_pr csa_q_rtpo_pr csa_s_spo_pr csa_q_spo_pr csa_s_rspo_pr csa_q_rspo_pr csa_s_tpo_pu csa_q_tpo_pu csa_s_rtpo_pu csa_q_rtpo_pu csa_s_spo_pu csa_q_spo_pu csa_s_tpo_pr_pu csa_q_tpo_pr_pu csa_s_rtpo_pr_pu csa_q_rtpo_pr_pu csa_s_spo_pr_pu csa_q_spo_pr_pu
+
+all:	$(TARGETS)
+clean:  $(BASEFILES)
+	rm $(TARGETS)
+
+interesting:	csa_s csa_s_qm csa_q csa_q_qm csa_s_pu csa_s_pu_qm csa_s_tpo_qm csa_s_spo_qm csa_s_spo csa_s_tpo csa_s_rtpo csa_s_rtpo_qm csa_s_rspo csa_s_rspo_qm
 
 links:		main.c parse.c stack.c timer.c list.c queue.c csa_defs.h
 	ln -s ../main.c main.c
@@ -177,6 +184,3 @@ csa_s_spo_pr_pu:	$(BASEFILES) $(HEADERS) p_refine.c p_update.c check_po_arcs.c l
 csa_q_spo_pr_pu:	$(BASEFILES) $(HEADERS) p_refine.c p_update.c check_po_arcs.c queue.c list.c
 	cc $(CFLAGS) -DUSE_PRICE_OUT -DSTRONG_PO -DUSE_P_UPDATE -DUSE_P_REFINE -DQUEUE_ORDER -o $@ $(BASEFILES) p_refine.c p_update.c check_po_arcs.c queue.c list.c -lm
 
-all:	csa_s csa_s_qm csa_q csa_q_qm csa_s_pr csa_q_pr csa_s_pr_qm csa_s_pu csa_s_pu_qm csa_q_pu csa_s_pr_pu csa_q_pr_pu csa_s_tpo csa_s_tpo_qm csa_q_tpo csa_s_rtpo csa_q_rtpo csa_s_rtpo_qm csa_s_spo csa_s_spo_qm csa_q_spo csa_s_rspo csa_s_rspo_qm csa_q_rspo csa_s_tpo_pr csa_q_tpo_pr csa_s_rtpo_pr csa_q_rtpo_pr csa_s_spo_pr csa_q_spo_pr csa_s_rspo_pr csa_q_rspo_pr csa_s_tpo_pu csa_q_tpo_pu csa_s_rtpo_pu csa_q_rtpo_pu csa_s_spo_pu csa_q_spo_pu csa_s_tpo_pr_pu csa_q_tpo_pr_pu csa_s_rtpo_pr_pu csa_q_rtpo_pr_pu csa_s_spo_pr_pu csa_q_spo_pr_pu
-
-interesting:	csa_s csa_s_qm csa_q csa_q_qm csa_s_pu csa_s_pu_qm csa_s_tpo_qm csa_s_spo_qm csa_s_spo csa_s_tpo csa_s_rtpo csa_s_rtpo_qm csa_s_rspo csa_s_rspo_qm

--- a/csa/prec_costs/Makefile
+++ b/csa/prec_costs/Makefile
@@ -32,7 +32,7 @@ TARGETS=csa_s csa_s_qm csa_q csa_q_qm csa_s_pr csa_q_pr csa_s_pr_qm csa_s_pu csa
 
 all:	$(TARGETS)
 clean:  $(BASEFILES)
-	rm $(TARGETS)
+	rm -f $(TARGETS)
 
 interesting:	csa_s csa_s_qm csa_q csa_q_qm csa_s_pu csa_s_pu_qm csa_s_tpo_qm csa_s_spo_qm csa_s_spo csa_s_tpo csa_s_rtpo csa_s_rtpo_qm csa_s_rspo csa_s_rspo_qm
 

--- a/csa/prec_costs/debug.c
+++ b/csa/prec_costs/debug.c
@@ -40,7 +40,7 @@ if (v->matched)
   }
 else
   (void) printf("unmatched\n");
-(void) printf("\t%d arcs priced out, %d arcs priced in\n",
+(void) printf("\t%ld arcs priced out, %ld arcs priced in\n",
 	      v->first - v->priced_out, (v+1)->priced_out - v->first);
 if ((v+1)->priced_out - v->first > 0)
   {
@@ -93,13 +93,13 @@ else
 for (b = v->priced_out; b != v->back_arcs; b++)
   {
   lhs_id = b->tail - head_lhs_node + 1;
-  (void) printf("Arc (%ld, %ld) back stored cost %lg (priced out)\n",
+  (void) printf("Arc (%d, %d) back stored cost %lg (priced out)\n",
 		lhs_id, rhs_id, b->c);
   }
 for (; b != (v+1)->priced_out; b++)
   {
   lhs_id = b->tail - head_lhs_node + 1;
-  (void) printf("Arc (%ld, %ld) back stored cost %lg (priced in) cmp cost %lg\n",
+  (void) printf("Arc (%d, %d) back stored cost %lg (priced in) cmp cost %lg\n",
 		lhs_id, rhs_id, b->c, b->c - v->p);
   }
 #endif

--- a/csa/prec_costs/p_update.c
+++ b/csa/prec_costs/p_update.c
@@ -1,4 +1,5 @@
 #include	<math.h>
+#include        <stdio.h>
 #include	"csa_types.h"
 #include	"csa_defs.h"
 

--- a/csa/queue.c
+++ b/csa/queue.c
@@ -15,13 +15,13 @@ void	exit();
 q = (queue) malloc(sizeof(struct queue_st));
 if (q == NULL)
   {
-  (void) printf(nomem_msg);
+  (void) printf("%s", nomem_msg);
   exit(9);
   }
 q->storage = (char **) malloc(sizeof(lhs_ptr) * (size + 1));
 if (q->storage == NULL)
   {
-  (void) printf(nomem_msg);
+  (void) printf("%s", nomem_msg);
   exit(9);
   }
 q->end = q->storage + size;

--- a/csa/round_costs/Makefile
+++ b/csa/round_costs/Makefile
@@ -20,7 +20,7 @@
 #
 BASEFILES=main.c refine.c update_epsilon.c parse.c stack.c timer.c debug.c
 HEADERS=csa_types.h csa_defs.h
-CFLAGS=-fast
+CFLAGS=
 
 links:		main.c parse.c stack.c timer.c list.c queue.c csa_defs.h
 	ln -s ../main.c main.c

--- a/csa/round_costs/Makefile
+++ b/csa/round_costs/Makefile
@@ -26,7 +26,7 @@ TARGETS=csa_s_tpo csa_q_tpo csa_s_rtpo csa_q_rtpo csa_s_spo csa_q_spo csa_s_rspo
 
 all:	$(TARGETS)
 clean:	$(TARGETS)
-	rm $(TARGETS)
+	rm -f $(TARGETS)
 
 links:		main.c parse.c stack.c timer.c list.c queue.c csa_defs.h
 	ln -s ../main.c main.c

--- a/csa/round_costs/Makefile
+++ b/csa/round_costs/Makefile
@@ -25,7 +25,7 @@ TARGETS=csa_s_tpo csa_q_tpo csa_s_rtpo csa_q_rtpo csa_s_spo csa_q_spo csa_s_rspo
 
 
 all:	$(TARGETS)
-clean:	$(TARGETS)
+clean:	$(BASEFILES)
 	rm -f $(TARGETS)
 
 links:		main.c parse.c stack.c timer.c list.c queue.c csa_defs.h

--- a/csa/round_costs/Makefile
+++ b/csa/round_costs/Makefile
@@ -21,6 +21,12 @@
 BASEFILES=main.c refine.c update_epsilon.c parse.c stack.c timer.c debug.c
 HEADERS=csa_types.h csa_defs.h
 CFLAGS=
+TARGETS=csa_s_tpo csa_q_tpo csa_s_rtpo csa_q_rtpo csa_s_spo csa_q_spo csa_s_rspo csa_q_rspo csa_s_tpo_pr csa_q_tpo_pr csa_s_rtpo_pr csa_q_rtpo_pr csa_s_spo_pr csa_q_spo_pr csa_s_rspo_pr csa_q_rspo_pr csa_s_tpo_pu csa_q_tpo_pu csa_s_rtpo_pu csa_q_rtpo_pu csa_s_spo_pu csa_q_spo_pu csa_s_tpo_pr_pu csa_q_tpo_pr_pu csa_s_rtpo_pr_pu csa_q_rtpo_pr_pu csa_s_spo_pr_pu csa_q_spo_pr_pu
+
+
+all:	$(TARGETS)
+clean:	$(TARGETS)
+	rm $(TARGETS)
 
 links:		main.c parse.c stack.c timer.c list.c queue.c csa_defs.h
 	ln -s ../main.c main.c
@@ -115,5 +121,3 @@ csa_s_spo_pr_pu:	$(BASEFILES) $(HEADERS) p_refine.c p_update.c check_po_arcs.c l
 
 csa_q_spo_pr_pu:	$(BASEFILES) $(HEADERS) p_refine.c p_update.c check_po_arcs.c queue.c list.c
 	cc $(CFLAGS) -DSTRONG_PO -DUSE_P_UPDATE -DUSE_P_REFINE -DQUEUE_ORDER -o $@ $(BASEFILES) p_refine.c p_update.c check_po_arcs.c queue.c list.c -lm
-
-all:	csa_s_tpo csa_q_tpo csa_s_rtpo csa_q_rtpo csa_s_spo csa_q_spo csa_s_rspo csa_q_rspo csa_s_tpo_pr csa_q_tpo_pr csa_s_rtpo_pr csa_q_rtpo_pr csa_s_spo_pr csa_q_spo_pr csa_s_rspo_pr csa_q_rspo_pr csa_s_tpo_pu csa_q_tpo_pu csa_s_rtpo_pu csa_q_rtpo_pu csa_s_spo_pu csa_q_spo_pu csa_s_tpo_pr_pu csa_q_tpo_pr_pu csa_s_rtpo_pr_pu csa_q_rtpo_pr_pu csa_s_spo_pr_pu csa_q_spo_pr_pu

--- a/csa/round_costs/debug.c
+++ b/csa/round_costs/debug.c
@@ -37,7 +37,7 @@ if (v->matched)
   }
 else
   (void) printf("unmatched\n");
-(void) printf("\t%d arcs priced out, %d arcs priced in\n",
+(void) printf("\t%ld arcs priced out, %ld arcs priced in\n",
 	      v->first - v->priced_out, (v+1)->priced_out - v->first);
 if ((v+1)->priced_out - v->first > 0)
   {

--- a/csa/round_costs/p_update.c
+++ b/csa/round_costs/p_update.c
@@ -1,4 +1,5 @@
 #include	<math.h>
+#include	<stdio.h>
 #include	"csa_types.h"
 #include	"csa_defs.h"
 

--- a/csa/stack.c
+++ b/csa/stack.c
@@ -33,13 +33,13 @@ s = (stack) malloc(sizeof(struct stack_st));
 
 if (s == NULL)
   {
-  (void) printf(nomem_msg);
+  (void) printf("%s", nomem_msg);
   exit(9);
   }
 s->bottom = (char **) malloc(size * sizeof(char *));
 if (s->bottom == NULL)
   {
-  (void) printf(nomem_msg);
+  (void) printf("%s", nomem_msg);
   exit(9);
   }
 s->top = s->bottom;


### PR DESCRIPTION
![](http://www.adverblog.com/wp-content/uploads/2012/01/cleaner.png)

At least on modern Linux with gcc, etc. (Currently working from Ubuntu 14.04 with `build-essential` installed).

Looking to make the build run without warnings, have a reasonable `Makefile`, etc. Will probably not be trying to get the DIMACS code to compile, as that seems to have actual errors, while CSA just has a number of warnings.
